### PR TITLE
addfriend and create group pages

### DIFF
--- a/ProjectSourceCode/src/views/pages/addFriends.hbs
+++ b/ProjectSourceCode/src/views/pages/addFriends.hbs
@@ -1,39 +1,22 @@
 {{> header}}
 
-<div class="container">
-    <button class="btn btn-primary">Add Friend</button>
-    <div class="row">
-        {{#each friends}}
-        <div class="col-sm-4">
-            <a href="/friends/{{this.id}}">
-                <img src="{{this.image}}" alt="{{this.name}}" class="img-thumbnail">
-                <h3>{{this.name}}</h3>
-            </a>
-        </div>
-        {{/each}}
-    </div>
+{{message}} {{!-- Friend request sent!, then displays the info of the friend who has been clicked (profile pic, , username, and name (if allowed in their settings)) --}}
 
-    <button class="btn btn-primary mt-4">Add Group</button>
-    <div class="row">
-        {{#each groups}}
-        <div class="col-sm-4">
-            <a href="/groups/{{this.id}}">
-                <img src="{{this.image}}" alt="{{this.name}}" class="img-thumbnail">
-                <h3>{{this.name}}</h3>
-            </a>
-        </div>
-        {{/each}}
-    </div>
+
+<div class="container">
+    <img src="{{friend.image}}" alt="{{friend.name}}" class="img-thumbnail">
+    <h3>{{friend.username}}</h3>
+    <p>{{friend.name}}</p>
 </div>
 
 {{> footer}}
-
-{{!--
-app.get('/friends/:id', (req, res) => {
-    // Fetch friend data using req.params.id and render the friend detail page
-});
-
-app.get('/groups/:id', (req, res) => {
-    // Fetch group data using req.params.id and render the group detail page
+{{!-- Example API
+app.get('/addFriends', (req, res) => {
+    const friend = {
+        username: 'friend1',
+        name: 'Friend One',
+        image: '/path/to/image.jpg',
+    };
+    res.render('addFriends', { friend });
 });
 --}}

--- a/ProjectSourceCode/src/views/pages/createGroup.hbs
+++ b/ProjectSourceCode/src/views/pages/createGroup.hbs
@@ -1,0 +1,35 @@
+{{> header}}
+
+{{message}} {{!-- Group created successfully!, then displays the info of the group, same as when clicking on group from home page (group pic, , users in the group, payment history, etc.--}}
+
+<div class="container">
+    <img src="{{group.image}}" alt="{{group.name}}" class="img-thumbnail">
+    <h3>{{group.name}}</h3>
+    <p>Users: {{group.users}}</p>
+    <p>Payment History: {{group.paymentHistory}}</p>
+</div>
+
+
+{{> footer}}
+
+{{!-- Example API 
+// Example API for group creation
+app.post('/api/groups', (req, res) => {
+    // Retrieve the necessary data from the request body
+    const { name, image, users, paymentHistory } = req.body;
+
+    // Perform any necessary validation on the data
+
+    // Create a new group object
+    const group = {
+        name,
+        image,
+        users,
+        paymentHistory
+    };
+
+    // Save the group to the database or perform any other necessary operations
+
+    // Return a success response with the created group
+    res.status(201).json({ message: 'Group created successfully!', group });
+});


### PR DESCRIPTION
Corrected functionality of creategroup and addfriends pages. both display a message, as well as the respective group/friend info after the button has been clicked on the main page. 

additionally, put example api routes in comments to show how the pages would work

STILL TODO
- Connect API routes so pages can be accessed
- For CreateGroup - Should we have a whole seperate page for a new group, or should it be the same page as when we click on an existing group? we would be showing the same info, just a different message
-for AddFriend, are we doing a friend request system?